### PR TITLE
Use video.js from CDN

### DIFF
--- a/docs/examples/simple-embed/index.html
+++ b/docs/examples/simple-embed/index.html
@@ -5,19 +5,14 @@
 
   <!-- Chang URLs to wherever Video.js files will be hosted -->
   <!-- Default URLs assume the examples folder is included alongside video.js -->
-  <link href="../../video-js.min.css" rel="stylesheet" type="text/css">
+  <link href="http://vjs.zencdn.net/5.0/video-js.css" rel="stylesheet" type="text/css">
 
   <!-- Include ES5 shim, sham and html5 shiv for ie8 support  -->
   <!-- Exclude this if you don't need ie8 support -->
-  <script src="../../ie8/videojs-ie8.min.js"></script>
+  <script src="http://vjs.zencdn.net/ie8/1.1.0/videojs-ie8.min.js"></script>
 
   <!-- video.js must be in the <head> for older IEs to work. -->
-  <script src="../../video.min.js"></script>
-
-  <!-- Unless using the CDN hosted version, update the URL to the Flash SWF -->
-  <script>
-    videojs.options.flash.swf = "../../video-js.swf";
-  </script>
+  <script src="http://vjs.zencdn.net/5.0/video.js"></script>
 
 </head>
 <body>


### PR DESCRIPTION
This PR fixes the example player in the simple embed link at http://docs.videojs.com/docs/examples/simple-embed/index.html
