### PR TITLE
Fix link to options page

### DIFF
--- a/docs/guides/setup.html
+++ b/docs/guides/setup.html
@@ -43,7 +43,7 @@ should Just Work™, but the paths can easily be changed by editing the LESS fil
 <p>Note: The <code>data-setup</code> attribute described here should not be used if you use the alternative setup described in the next section.</p>
 </blockquote>
 <ol>
-<li><p>The &#39;data-setup&#39; Attribute tells Video.js to automatically set up the video when the page is ready, and read any options (in JSON format) from the attribute (see <a href="options.md">options</a>). There are other methods for initializing the player, but this is the easiest.</p>
+<li><p>The &#39;data-setup&#39; Attribute tells Video.js to automatically set up the video when the page is ready, and read any options (in JSON format) from the attribute (see <a href="options.html">options</a>). There are other methods for initializing the player, but this is the easiest.</p>
 </li>
 <li><p>The &#39;id&#39; Attribute: Should be used and unique for every video on the same page.</p>
 </li>


### PR DESCRIPTION
The link to the options docs from the setup page was broken because the extension was md not html. Possibly left over from older versions of docs?
