### PR TITLE
Update CDN URL in setup

### DIFF
--- a/docs/guides/setup.html
+++ b/docs/guides/setup.html
@@ -17,8 +17,8 @@
 <pre><code class="lang-html">&lt;script src=&quot;//vjs.zencdn.net/ie8/1.1.1/videojs-ie8.min.js&quot;&gt;&lt;/script&gt;
 </code></pre>
 <h3 id="cdn-version">CDN Version</h3>
-<pre><code class="lang-html">&lt;link href=&quot;//vjs.zencdn.net/4.12/video-js.min.css&quot; rel=&quot;stylesheet&quot;&gt;
-&lt;script src=&quot;//vjs.zencdn.net/4.12/video.min.js&quot;&gt;&lt;/script&gt;
+<pre><code class="lang-html">&lt;link href=&quot;//vjs.zencdn.net/5.4.4/video-js.min.css&quot; rel=&quot;stylesheet&quot;&gt;
+&lt;script src=&quot;//vjs.zencdn.net/5.4.4/video.min.js&quot;&gt;&lt;/script&gt;
 </code></pre>
 <p>We include a stripped down Google Analytics pixel that tracks a random percentage (currently 1%) of players loaded from the CDN. This allows us to see (roughly) what browsers are in use in the wild, along with other useful metrics such as OS and device. If you&#39;d like to disable analytics, you can simply include the following global <strong>before</strong> including Video.js:</p>
 <pre><code class="lang-js">window.HELP_IMPROVE_VIDEOJS = false;


### PR DESCRIPTION
The setup guide has broken links to non-existent 4.12 files. This updates the URL to 5.4.4.

Quick fix as this is making things difficult for new users, e.g. videojs/video.js#2977; it would be better to have this updating to the latest release automatically.
