### PR TITLE
precompile step for markdown to fix links in the guides folder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,9 @@ module.exports = function (grunt) {
                     }
                 ],
                 options: {
+                    preCompile: function(src, context) {
+                        return src.replace(/\.\/(.*)\.md/g, "./$1.html");
+                    },
                     template: 'templates/guide-template.html',
                     markdownOptions: {
                         gfm: true


### PR DESCRIPTION
Noticed the links were broken and decided to write a quick fix, I did not run it on the docs (other than to test that it works) as they appear to not be up to date with the current video.js master.

This should resolve #25 after we re-generate the docs with these changes.
